### PR TITLE
Broaden `psr/log` version support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=8.0",
-        "psr/log": "^1",
+        "psr/log": "^1 || ^2 || ^3",
         "psr/http-message": "^1",
         "psr/http-server-middleware": "^1"
     },

--- a/src/ChromeLogger.php
+++ b/src/ChromeLogger.php
@@ -78,7 +78,7 @@ class ChromeLogger extends AbstractLogger implements LoggerInterface
      *
      * @return void
      */
-    public function log($level, $message, array $context = [])
+    public function log($level, $message, array $context = []): void
     {
         $this->entries[] = new LogEntry($level, $message, $context);
     }


### PR DESCRIPTION
Two new major versions of `psr/log` have been released with stronger typing (see https://www.php-fig.org/psr/psr-3/meta/#5-errata for details.)

Support for these new versions will prevent dependency conflicts (e.g. Monolog v3 does not support `psr/log` 1.x, and therefore cannot currently be installed alongside `chrome-logger`.)

This PR updates the supported `psr/log` versions and adds a return type to `ChromeLogger::log` to satisfy covariance requirements. It does **not** add parameter types, as that would require a new major version and dropping support for `psr/log` 1.x.